### PR TITLE
fix: correct url for virtual ws

### DIFF
--- a/cmd/listener.go
+++ b/cmd/listener.go
@@ -91,6 +91,11 @@ var listenCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := ctrl.SetupSignalHandler()
 		restCfg := ctrl.GetConfigOrDie()
+		log, err := setupLogger(appCfg.LogLevel)
+		if err != nil {
+			setupLog.Error(err, "unable to setup logger")
+			os.Exit(1)
+		}
 
 		mgrOpts := ctrl.Options{
 			Scheme:                 scheme,
@@ -109,7 +114,7 @@ var listenCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		mf := kcp.NewManagerFactory(appCfg)
+		mf := kcp.NewManagerFactory(log, appCfg)
 
 		mgr, err := mf.NewManager(ctx, restCfg, mgrOpts, clt)
 		if err != nil {
@@ -132,6 +137,7 @@ var listenCmd = &cobra.Command{
 
 		reconciler, err := kcp.NewReconciler(
 			ctx,
+			log,
 			appCfg,
 			reconcilerOpts,
 			discoveryInterface,

--- a/listener/kcp/manager_factory.go
+++ b/listener/kcp/manager_factory.go
@@ -3,7 +3,7 @@ package kcp
 import (
 	"context"
 	"errors"
-
+	"github.com/openmfp/golang-commons/logger"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -15,10 +15,12 @@ import (
 
 type ManagerFactory struct {
 	appConfig config.Config
+	log       *logger.Logger
 }
 
-func NewManagerFactory(appCfg config.Config) *ManagerFactory {
+func NewManagerFactory(log *logger.Logger, appCfg config.Config) *ManagerFactory {
 	return &ManagerFactory{
+		log:       log,
 		appConfig: appCfg,
 	}
 }
@@ -28,7 +30,7 @@ func (f *ManagerFactory) NewManager(ctx context.Context, restCfg *rest.Config, o
 		return ctrl.NewManager(restCfg, opts)
 	}
 
-	virtualWorkspaceCfg, err := virtualWorkspaceConfigFromCfg(ctx, f.appConfig, restCfg, clt)
+	virtualWorkspaceCfg, err := virtualWorkspaceConfigFromCfg(ctx, f.log, f.appConfig, restCfg, clt)
 	if err != nil {
 		return nil, errors.Join(ErrGetVWConfig, err)
 	}

--- a/listener/kcp/manager_factory_test.go
+++ b/listener/kcp/manager_factory_test.go
@@ -51,7 +51,7 @@ func TestNewManager(t *testing.T) {
 
 			mgr, err := f.NewManager(
 				context.Background(),
-				&rest.Config{},
+				&rest.Config{Host: validAPIServerHost},
 				ctrl.Options{Scheme: scheme},
 				fakeClient,
 			)

--- a/listener/kcp/manager_factory_test.go
+++ b/listener/kcp/manager_factory_test.go
@@ -2,7 +2,9 @@ package kcp
 
 import (
 	"context"
+	"github.com/openmfp/golang-commons/logger"
 	"github.com/openmfp/kubernetes-graphql-gateway/common/config"
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	kcpapis "github.com/kcp-dev/kcp/sdk/apis/apis/v1alpha1"
@@ -24,6 +26,9 @@ func TestNewManager(t *testing.T) {
 		"successful_KCP_manager_creation": {isKCPEnabled: true, expectErr: false},
 		"successful_manager_creation":     {isKCPEnabled: false, expectErr: false},
 	}
+
+	log, err := logger.New(logger.DefaultConfig())
+	require.NoError(t, err)
 
 	for name, tc := range tests {
 		scheme := runtime.NewScheme()
@@ -47,7 +52,7 @@ func TestNewManager(t *testing.T) {
 				},
 			}...).Build()
 
-			f := NewManagerFactory(appCfg)
+			f := NewManagerFactory(log, appCfg)
 
 			mgr, err := f.NewManager(
 				context.Background(),

--- a/listener/kcp/reconciler_factory.go
+++ b/listener/kcp/reconciler_factory.go
@@ -3,6 +3,7 @@ package kcp
 import (
 	"context"
 	"errors"
+	"github.com/openmfp/golang-commons/logger"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -50,6 +51,7 @@ type ReconcilerOpts struct {
 
 func NewReconciler(
 	ctx context.Context,
+	log *logger.Logger,
 	appCfg config.Config,
 	opts ReconcilerOpts,
 	discoveryInterface discovery.DiscoveryInterface,
@@ -60,7 +62,7 @@ func NewReconciler(
 		return newStandardReconciler(opts, discoveryInterface, preReconcileFunc)
 	}
 
-	return newKcpReconciler(ctx, appCfg, opts, discoverFactory)
+	return newKcpReconciler(ctx, log, appCfg, opts, discoverFactory)
 }
 
 func newStandardReconciler(
@@ -120,6 +122,7 @@ func PreReconcile(
 
 func newKcpReconciler(
 	ctx context.Context,
+	log *logger.Logger,
 	appCfg config.Config,
 	opts ReconcilerOpts,
 	newDiscoveryFactoryFunc func(cfg *rest.Config) (*discoveryclient.Factory, error),
@@ -134,7 +137,7 @@ func newKcpReconciler(
 		return nil, errors.Join(ErrCreatePathResolver, err)
 	}
 
-	virtualWorkspaceCfg, err := virtualWorkspaceConfigFromCfg(ctx, appCfg, opts.Config, opts.Client)
+	virtualWorkspaceCfg, err := virtualWorkspaceConfigFromCfg(ctx, log, appCfg, opts.Config, opts.Client)
 	if err != nil {
 		return nil, errors.Join(ErrGetVWConfig, err)
 	}

--- a/listener/kcp/reconciler_factory_test.go
+++ b/listener/kcp/reconciler_factory_test.go
@@ -3,9 +3,11 @@ package kcp
 import (
 	"context"
 	"errors"
+	"github.com/openmfp/golang-commons/logger"
 	"github.com/openmfp/kubernetes-graphql-gateway/common/config"
 	"github.com/openmfp/kubernetes-graphql-gateway/listener/clusterpath"
 	"github.com/openmfp/kubernetes-graphql-gateway/listener/kcp/mocks"
+	"github.com/stretchr/testify/require"
 	"path"
 	"testing"
 
@@ -71,6 +73,9 @@ func TestNewReconciler(t *testing.T) {
 		},
 	}
 
+	log, err := logger.New(logger.DefaultConfig())
+	require.NoError(t, err)
+
 	for name, tc := range tests {
 		scheme := runtime.NewScheme()
 		assert.NoError(t, kcpapis.AddToScheme(scheme))
@@ -96,6 +101,7 @@ func TestNewReconciler(t *testing.T) {
 
 			reconciler, err := NewReconciler(
 				context.Background(),
+				log,
 				appCfg,
 				ReconcilerOpts{
 					Config:                 tc.cfg,

--- a/listener/kcp/workspace_config_test.go
+++ b/listener/kcp/workspace_config_test.go
@@ -106,7 +106,7 @@ func TestVirtualWorkspaceConfigFromCfg(t *testing.T) {
 			}
 			fakeClient := fakeClientBuilder.Build()
 
-			resultCfg, err := virtualWorkspaceConfigFromCfg(context.Background(), appCfg, &rest.Config{Host: "https://192.168.1.13:6443"}, fakeClient)
+			resultCfg, err := virtualWorkspaceConfigFromCfg(context.Background(), appCfg, &rest.Config{Host: validAPIServerHost}, fakeClient)
 
 			if tc.err != nil {
 				assert.EqualError(t, err, tc.err.Error())


### PR DESCRIPTION
When we create ApiExport, it assigns to virtual workspace url address with external host, which is not resolvable within openmfp cluster.
The solution is to take the host address that is present in kubeconfig and replace original virtual workspace url host.
It works in both cases - in openmpf and outside it.

Also, I added a change for local development - app is not failing in case of kubernetes.graphql.gateway apixexport absence, it starts but prints warning that ApiBindings are not watched.

On-behalf-of: @SAP a.shcherbatiuk@sap.com