### PR TITLE
feat: profiling

### DIFF
--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"net/http"
+	_ "net/http/pprof"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -28,6 +29,13 @@ var gatewayCmd = &cobra.Command{
 		appCfg, err := appConfig.NewFromEnv()
 		if err != nil {
 			log.Fatal().Err(err).Msg("Error getting app restCfg, exiting")
+		}
+
+		if appCfg.EnablePprof {
+			go func() {
+				log.Info().Msgf("Starting pprof server on port %s", appCfg.Gateway.PprofPort)
+				http.ListenAndServe(fmt.Sprintf(":%s", appCfg.Gateway.PprofPort), nil) // nolint:errcheck
+			}()
 		}
 
 		log, err := setupLogger(appCfg.LogLevel)

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -11,10 +11,12 @@ type Config struct {
 	OpenApiDefinitionsPath string `envconfig:"default=./bin/definitions"`
 	EnableKcp              bool   `envconfig:"default=true,optional"`
 	LocalDevelopment       bool   `envconfig:"default=false,optional"`
+	EnablePprof            bool   `envconfig:"default=false,optional"`
 }
 
 type Gateway struct {
 	Port              string `envconfig:"default=8080,optional"`
+	PprofPort         string `envconfig:"default=6060,optional"`
 	LogLevel          string `envconfig:"default=INFO,optional"`
 	UserNameClaim     string `envconfig:"default=email,optional"`
 	ShouldImpersonate bool   `envconfig:"default=true,optional"`
@@ -33,6 +35,7 @@ type Gateway struct {
 }
 
 type Listener struct {
+	PprofPort            string `envconfig:"default=6061,optional"`
 	MetricsAddr          string `envconfig:"default=0,optional"`
 	EnableLeaderElection bool   `envconfig:"default=false,optional"`
 	ProbeAddr            string `envconfig:"default=:8081,optional"`

--- a/main.go
+++ b/main.go
@@ -1,7 +1,16 @@
 package main
 
-import "github.com/openmfp/kubernetes-graphql-gateway/cmd"
+import (
+	"net/http"
+	_ "net/http/pprof"
+
+	"github.com/openmfp/kubernetes-graphql-gateway/cmd"
+)
 
 func main() {
+	go func() {
+		http.ListenAndServe("localhost:6060", nil)
+	}()
+
 	cmd.Execute()
 }

--- a/main.go
+++ b/main.go
@@ -1,16 +1,9 @@
 package main
 
 import (
-	"net/http"
-	_ "net/http/pprof"
-
 	"github.com/openmfp/kubernetes-graphql-gateway/cmd"
 )
 
 func main() {
-	go func() {
-		http.ListenAndServe("localhost:6060", nil)
-	}()
-
 	cmd.Execute()
 }


### PR DESCRIPTION
Despite 2GB of memory, kubernetes-graphql-gateway deployment in dev cluster is hitting the limit.
Meanwhile, at local run during idle state it takes up to 30mb of memory, which is 70 times less.
I added pprof endpoint to check out what is happening in dev cluster.