### PR TITLE
Feat/correct plural form

### DIFF
--- a/gateway/schema/exports_test.go
+++ b/gateway/schema/exports_test.go
@@ -1,3 +1,19 @@
 package schema
 
-var StringMapScalar = stringMapScalar
+import "k8s.io/apimachinery/pkg/runtime/schema"
+
+var StringMapScalarForTest = stringMapScalar
+
+func GetPluralNameForTest(singular string) string {
+	return getPluralName(singular)
+}
+
+func GetGatewayForTest(typeNameRegistry map[string]string) *Gateway {
+	return &Gateway{
+		typeNameRegistry: typeNameRegistry,
+	}
+}
+
+func (g *Gateway) GetNamesForTest(gvk *schema.GroupVersionKind) (singular, plural string) {
+	return g.getNames(gvk)
+}

--- a/gateway/schema/scalars_test.go
+++ b/gateway/schema/scalars_test.go
@@ -29,7 +29,7 @@ func TestStringMapScalar_ParseValue(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		out := schema.StringMapScalar.ParseValue(test.input)
+		out := schema.StringMapScalarForTest.ParseValue(test.input)
 		if !reflect.DeepEqual(out, test.expected) {
 			t.Errorf("ParseValue(%v) = %v; want %v", test.input, out, test.expected)
 		}
@@ -68,7 +68,7 @@ func TestStringMapScalar_ParseLiteral(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			out := schema.StringMapScalar.ParseLiteral(tt.input)
+			out := schema.StringMapScalarForTest.ParseLiteral(tt.input)
 			if !reflect.DeepEqual(out, tt.expected) {
 				t.Errorf("ParseLiteral() = %v, want %v", out, tt.expected)
 			}

--- a/gateway/schema/schema_test.go
+++ b/gateway/schema/schema_test.go
@@ -1,0 +1,72 @@
+package schema_test
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	gatewaySchema "github.com/openmfp/kubernetes-graphql-gateway/gateway/schema"
+)
+
+func TestGetPluralName(t *testing.T) {
+	tests := []struct {
+		singular string
+		want     string
+	}{
+		{"", ""},
+		{"dog", "dogs"},
+		{"bus", "buses"},
+		{"class", "classes"},
+		{"box", "boxes"},
+		{"church", "churches"},
+		{"brush", "brushes"},
+		{"baby", "babies"},
+		{"toy", "toys"},
+	}
+
+	for _, tt := range tests {
+		got := gatewaySchema.GetPluralNameForTest(tt.singular)
+		if got != tt.want {
+			t.Errorf("getPluralName(%q) = %q, want %q", tt.singular, got, tt.want)
+		}
+	}
+}
+
+func TestGateway_getNames(t *testing.T) {
+	type testCase struct {
+		name         string
+		registry     map[string]string
+		gvk          schema.GroupVersionKind
+		wantSingular string
+		wantPlural   string
+	}
+
+	tests := []testCase{
+		{
+			name:         "no_conflict",
+			registry:     map[string]string{},
+			gvk:          schema.GroupVersionKind{Group: "core", Version: "v1", Kind: "Pod"},
+			wantSingular: "Pod",
+			wantPlural:   "Pods",
+		},
+		{
+			name:         "same_kind_different_group_version",
+			registry:     map[string]string{"Pod": "core/v1"},
+			gvk:          schema.GroupVersionKind{Group: "custom.io", Version: "v2", Kind: "Pod"},
+			wantSingular: "Pod_customio_v2",
+			wantPlural:   "Pods_customio_v2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gatewaySchema.GetGatewayForTest(tt.registry)
+			gotSingular, gotPlural := g.GetNamesForTest(&tt.gvk)
+
+			if gotSingular != tt.wantSingular || gotPlural != tt.wantPlural {
+				t.Errorf("getNames() = (%q, %q), want (%q, %q)",
+					gotSingular, gotPlural, tt.wantSingular, tt.wantPlural)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Resolves #156 

# Changes
- Extended getNames method by covering plural forms:
{"dog", "dogs"},
{"bus", "buses"},
{"class", "classes"},
{"box", "boxes"},
{"church", "churches"},
{"brush", "brushes"},
{"baby", "babies"},
{"toy", "toys"}
- If the kind name has already been used for a different group/version, I use proper plural form for it. Also, I added underscore for better readability:
Before: Podcustomiov2s
Now: Pods_customio_v2
- Unit tests for mentioned features.