### PR TITLE
fix: nil-pointer-dereference

### DIFF
--- a/gateway/resolver/subscription.go
+++ b/gateway/resolver/subscription.go
@@ -186,7 +186,12 @@ func (r *Service) runWatch(
 					select {
 					case <-ctx.Done():
 						return
-					case resultChannel <- singleObj.Object:
+					case resultChannel <- func() interface{} {
+						if singleObj == nil { // object will be nil in case it is deleted
+							return nil
+						}
+						return singleObj.Object
+					}():
 					}
 				} else {
 					items := make([]unstructured.Unstructured, 0, len(previousObjects))

--- a/tests/gateway_test/subscription_test.go
+++ b/tests/gateway_test/subscription_test.go
@@ -26,12 +26,13 @@ func (suite *CommonTestSuite) TestSchemaSubscribe() {
 		expectError    bool
 	}{
 		{
-			testName:       "subscribe_deployment_and_create_deployment_OK",
+			testName:       "subscribe_create_and_delete_deployment_OK",
 			subscribeQuery: SubscribeDeployment("my-new-deployment", false),
 			setupFunc: func(ctx context.Context) {
 				suite.createDeployment(ctx, "my-new-deployment", map[string]string{"app": "my-app"})
+				suite.deleteDeployment(ctx, "my-new-deployment")
 			},
-			expectedEvents: 1,
+			expectedEvents: 2,
 		},
 		{
 			testName:       "subscribe_to_replicas_change_OK",


### PR DESCRIPTION
Issue: When you subscribe to a single item and it is deleted, gateway fails with the nil pointer dereference.

# Changes
- Added nil check to handle this case.
- Covered this case in test.

In case of deletion the user receives object with null fields. Check the screenshot.
Let me know if this behavior makes sense. @aaronschweig 
Other options:
1. We can return an error. Already implemented in existing schema.
2. We can return a map with "deleted: true". Needs additional graphql schema change.

# Testing
- Subscribe to a specific item
- Create item
- Delete item
- Create it again
Result - subscription is working.

Also tested the same scenario with SubscribeToItems(Multiple). It is working.

<img width="955" alt="Screenshot 2025-05-20 at 16 21 37" src="https://github.com/user-attachments/assets/8fef1c5f-4094-4fcd-a200-22b4a4506c7b" />


On-behalf-of: @SAP a.shcherbatiuk@sap.com
