### PR TITLE
fix: rountripper

### DIFF
--- a/gateway/manager/handler.go
+++ b/gateway/manager/handler.go
@@ -68,7 +68,7 @@ func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.setContexts(r, workspace, token)
+	r = s.setContexts(r, workspace, token)
 
 	if r.Header.Get("Accept") == "text/event-stream" {
 		s.handleSubscription(w, r, h.schema)
@@ -214,6 +214,7 @@ func (s *Service) setContexts(r *http.Request, workspace, token string) *http.Re
 	if s.AppCfg.EnableKcp {
 		r = r.WithContext(kontext.WithCluster(r.Context(), logicalcluster.Name(workspace)))
 	}
+
 	return r.WithContext(context.WithValue(r.Context(), TokenKey{}, token))
 }
 

--- a/gateway/manager/manager.go
+++ b/gateway/manager/manager.go
@@ -46,7 +46,15 @@ func NewManager(log *logger.Logger, cfg *rest.Config, appCfg appConfig.Config) (
 	cfg.Host = fmt.Sprintf("%s://%s", u.Scheme, u.Host)
 
 	cfg.Wrap(func(rt http.RoundTripper) http.RoundTripper {
-		return NewRoundTripper(log, rt, appCfg.Gateway.UsernameClaim, appCfg.Gateway.ShouldImpersonate)
+		return NewRoundTripper(
+			log,
+			rt,
+			NewTokenOnlyTransport(cfg.TLSClientConfig),
+			NewUnauthorizedRoundTripper(),
+			appCfg.Gateway.UsernameClaim,
+			appCfg.Gateway.ShouldImpersonate,
+			cfg.TLSClientConfig,
+		)
 	})
 
 	runtimeClient, err := kcp.NewClusterAwareClientWithWatch(cfg, client.Options{})


### PR DESCRIPTION
Resolves #216 

# Changes
- Introduced two more roundtripers to handle requests properly:
- - tokenOnlyRT that relies solely on user token
- - unauthorizedRT returns always 401 and is called in case of error

# Testing
- Checked it with valid token and expired token with impersonation == false
- Impersonation == true case:
- - Tested with this command to see if token is parsed:
```
TOKEN="$(echo -n '{"alg":"none","typ":"JWT"}' | base64 | tr -d '=' | tr '/+' '_-' ).$(echo -n '{"email":"test@example.com"}' | base64 | tr -d '=' | tr '/+' '_-' )."
```
But haven't tested it e2e because I didn't find the way to generate valid token with claims for Service Account.



On-behalf-of: @SAP a.shcherbatiuk@sap.com