### PR TITLE
fix: prevent overwriting schema in PreReconcile

### DIFF
--- a/listener/kcp/reconciler_factory.go
+++ b/listener/kcp/reconciler_factory.go
@@ -111,30 +111,23 @@ func PreReconcile(
 ) error {
 	actualJSON, err := cr.Resolve()
 	if err != nil {
-		// If we cannot resolve the schema, we return an error.
 		return errors.Join(ErrResolveSchema, err)
 	}
 
 	savedJSON, err := io.Read(kubernetesClusterName)
 	if err != nil {
-		// If we cannot read the file, we check if it is because the file does not exist.
 		if errors.Is(err, workspacefile.ErrNotFound) {
-			// If the file does not exist, we write the actual JSON to the filesystem.
 			return io.Write(actualJSON, kubernetesClusterName)
 		}
-		// If we cannot read the file, we return an error.
 		return errors.Join(ErrReadJSON, err)
 	}
 
 	if !bytes.Equal(actualJSON, savedJSON) {
-		// If the actual JSON is different from the saved JSON, we write the actual JSON to the filesystem.
 		if err := io.Write(actualJSON, kubernetesClusterName); err != nil {
-			// If we cannot write the file, we return an error.
 			return errors.Join(ErrWriteJSON, err)
 		}
 	}
 
-	// If the actual JSON is the same as the saved JSON, we do nothing.
 	return nil
 }
 

--- a/listener/workspacefile/io_handler.go
+++ b/listener/workspacefile/io_handler.go
@@ -38,6 +38,9 @@ func (h *IOHandlerProvider) Read(clusterName string) ([]byte, error) {
 	fileName := path.Join(h.schemasDir, clusterName)
 	JSON, err := os.ReadFile(fileName)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrNotFound
+		}
 		return nil, errors.Join(ErrReadJSONFile, err)
 	}
 	return JSON, nil

--- a/listener/workspacefile/io_handler.go
+++ b/listener/workspacefile/io_handler.go
@@ -11,6 +11,7 @@ var (
 	ErrReadJSONFile     = errors.New("failed to read JSON file")
 	ErrWriteJSONFile    = errors.New("failed to write JSON to file")
 	ErrDeleteJSONFile   = errors.New("failed to delete JSON file")
+	ErrNotFound         = errors.New("failed to find JSON file")
 )
 
 type IOHandler interface {


### PR DESCRIPTION
#103 

Adds logic to PreReconcile to avoid overwriting the existing `OpenAPI` schema file if the resolved schema matches what's already saved.

When deleting definitions/kubernetes schema, the task listener now creates a new one.

**Testing**:
`task test`

Deleted the scheme:
`rm -f bin/definitions/kubernetes`

Started listener:
`task listener`

Checked file:
`ls -l bin/definitions/kubernetes`

Return:
`... May 30 14:49 bin/definitions/kubernetes`

Turned off the listener and started it again after a few minutes, then checked the file again.:
`... May 30 14:49 bin/definitions/kubernetes`

Schema wasn't updated.

Can't test it in KCP because:
```
if !appCfg.EnableKcp {
  return newStandardReconciler(opts, discoveryInterface, preReconcileFunc, log)
}
return newKcpReconciler(opts, restcfg, discoverFactory, log)
```
When ENABLE_KCP=true, the KCP path (newKcpReconciler) is used, and PreReconcile logic is not called at all.
