### PR TITLE
fix: no cluster name

### DIFF
--- a/gateway/manager/export_test.go
+++ b/gateway/manager/export_test.go
@@ -1,6 +1,8 @@
 package manager
 
 import (
+	"net/http"
+
 	"github.com/openmfp/golang-commons/logger/testlogger"
 	appConfig "github.com/openmfp/kubernetes-graphql-gateway/common/config"
 )
@@ -20,4 +22,12 @@ func NewManagerForTest() *Service {
 	s.handlers.registry["testws"] = &graphqlHandler{}
 
 	return s
+}
+
+func (s *Service) SetHandlerForTest(workspace string, handler http.Handler) {
+	s.handlers.mu.Lock()
+	defer s.handlers.mu.Unlock()
+	s.handlers.registry[workspace] = &graphqlHandler{
+		handler: handler,
+	}
 }

--- a/gateway/manager/handler.go
+++ b/gateway/manager/handler.go
@@ -68,7 +68,7 @@ func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.setContexts(r, workspace, token)
+	r = s.setContexts(r, workspace, token)
 
 	if r.Header.Get("Accept") == "text/event-stream" {
 		s.handleSubscription(w, r, h.schema)

--- a/gateway/manager/handler_test.go
+++ b/gateway/manager/handler_test.go
@@ -1,11 +1,15 @@
 package manager_test
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/kcp-dev/logicalcluster/v3"
 	"github.com/openmfp/kubernetes-graphql-gateway/gateway/manager"
+	"sigs.k8s.io/controller-runtime/pkg/kontext"
 )
 
 func TestServeHTTP_CORSPreflight(t *testing.T) {
@@ -39,5 +43,34 @@ func TestServeHTTP_AuthRequired_NoToken(t *testing.T) {
 	s.ServeHTTP(w, req)
 	if w.Code != http.StatusUnauthorized {
 		t.Errorf("expected 401 for missing token, got %d", w.Code)
+	}
+}
+
+func TestServeHTTP_CheckClusterNameInRequest(t *testing.T) {
+	s := manager.NewManagerForTest()
+	s.AppCfg.EnableKcp = true
+	s.AppCfg.LocalDevelopment = true
+
+	var capturedCtx context.Context
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedCtx = r.Context()
+		w.WriteHeader(http.StatusOK)
+	})
+	s.SetHandlerForTest("testws", testHandler)
+
+	req := httptest.NewRequest(http.MethodPost, "/testws/graphql", strings.NewReader(`{}`))
+	req.Header.Set("Authorization", "Bearer test-token")
+
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+
+	cluster, ok := kontext.ClusterFrom(capturedCtx)
+	if !ok || cluster != logicalcluster.Name("testws") {
+		t.Errorf("expected workspace 'testws' in context, got %v (found: %t)", cluster, ok)
+	}
+
+	token, ok := capturedCtx.Value(manager.TokenKey{}).(string)
+	if !ok || token != "test-token" {
+		t.Errorf("expected token 'test-token' in context, got %v (found: %t)", token, ok)
 	}
 }


### PR DESCRIPTION
One line bug. Shame on me!

P.S. Added test to ensure we have this in the context.

On-behalf-of: @SAP a.shcherbatiuk@sap.com