### PR TITLE
fixed not found issue

### DIFF
--- a/listener/controller/crd_controller.go
+++ b/listener/controller/crd_controller.go
@@ -15,9 +15,7 @@ import (
 )
 
 var (
-	ErrReadJSON         = errors.New("failed to read JSON from filesystem")
 	ErrResolveSchema    = errors.New("failed to resolve server JSON schema")
-	ErrWriteJSON        = errors.New("failed to write JSON to filesystem")
 	ErrGetReconciledObj = errors.New("failed to get reconciled object")
 )
 
@@ -79,7 +77,7 @@ func (r *CRDReconciler) SetupWithManager(mgr ctrl.Manager) error {
 func (r *CRDReconciler) updateAPISchema() error {
 	savedJSON, err := r.io.Read(r.ClusterName)
 	if err != nil {
-		return errors.Join(ErrReadJSON, err)
+		return err
 	}
 	actualJSON, err := r.Resolve()
 	if err != nil {
@@ -87,7 +85,7 @@ func (r *CRDReconciler) updateAPISchema() error {
 	}
 	if !bytes.Equal(actualJSON, savedJSON) {
 		if err := r.io.Write(actualJSON, r.ClusterName); err != nil {
-			return errors.Join(ErrWriteJSON, err)
+			return err
 		}
 	}
 	return nil
@@ -96,7 +94,7 @@ func (r *CRDReconciler) updateAPISchema() error {
 func (r *CRDReconciler) updateAPISchemaWith(crd *apiextensionsv1.CustomResourceDefinition) error {
 	savedJSON, err := r.io.Read(r.ClusterName)
 	if err != nil {
-		return errors.Join(ErrReadJSON, err)
+		return err
 	}
 	actualJSON, err := r.ResolveApiSchema(crd)
 	if err != nil {
@@ -104,7 +102,7 @@ func (r *CRDReconciler) updateAPISchemaWith(crd *apiextensionsv1.CustomResourceD
 	}
 	if !bytes.Equal(actualJSON, savedJSON) {
 		if err := r.io.Write(actualJSON, r.ClusterName); err != nil {
-			return errors.Join(ErrWriteJSON, err)
+			return err
 		}
 	}
 	return nil

--- a/listener/controller/crd_controller_test.go
+++ b/listener/controller/crd_controller_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openmfp/kubernetes-graphql-gateway/gateway/resolver/mocks"
 	"github.com/openmfp/kubernetes-graphql-gateway/listener/controller"
 	controllerMocks "github.com/openmfp/kubernetes-graphql-gateway/listener/controller/mocks"
+	"github.com/openmfp/kubernetes-graphql-gateway/listener/workspacefile"
 	workspacefileMocks "github.com/openmfp/kubernetes-graphql-gateway/listener/workspacefile/mocks"
 
 	"github.com/openmfp/golang-commons/logger/testlogger"
@@ -40,8 +41,8 @@ func TestCRDReconciler(t *testing.T) {
 		{
 			name:    "not_found_read_error",
 			getErr:  apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "crds"}, "my-crd"),
-			readErr: errors.New("read-error"),
-			wantErr: controller.ErrReadJSON,
+			readErr: workspacefile.ErrReadJSONFile,
+			wantErr: workspacefile.ErrReadJSONFile,
 		},
 		{
 			name:    "not_found_resolve_error",
@@ -53,7 +54,7 @@ func TestCRDReconciler(t *testing.T) {
 			name:    "not_found_write_error",
 			getErr:  apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "crds"}, "my-crd"),
 			readErr: nil,
-			wantErr: controller.ErrWriteJSON,
+			wantErr: workspacefile.ErrWriteJSONFile,
 		},
 		{
 			name:    "successful_update",
@@ -89,11 +90,11 @@ func TestCRDReconciler(t *testing.T) {
 				if tc.readErr == nil {
 					if tc.wantErr == controller.ErrResolveSchema {
 						crdResolver.EXPECT().Resolve().Return(nil, errors.New("resolve error"))
-					} else if tc.wantErr == controller.ErrWriteJSON {
+					} else if tc.wantErr == workspacefile.ErrWriteJSONFile {
 						crdResolver.EXPECT().Resolve().Return([]byte(`{"new":"schema"}`), nil)
 						ioHandler.EXPECT().
 							Write([]byte(`{"new":"schema"}`), "cluster1").
-							Return(errors.New("write error"))
+							Return(workspacefile.ErrWriteJSONFile)
 					} else {
 						crdResolver.EXPECT().Resolve().Return([]byte("{}"), nil)
 					}

--- a/listener/kcp/reconciler_factory.go
+++ b/listener/kcp/reconciler_factory.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io/fs"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -116,7 +117,7 @@ func PreReconcile(
 
 	savedJSON, err := io.Read(kubernetesClusterName)
 	if err != nil {
-		if errors.Is(err, workspacefile.ErrNotFound) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return io.Write(actualJSON, kubernetesClusterName)
 		}
 		return errors.Join(ErrReadJSON, err)

--- a/listener/workspacefile/io_handler.go
+++ b/listener/workspacefile/io_handler.go
@@ -11,7 +11,6 @@ var (
 	ErrReadJSONFile     = errors.New("failed to read JSON file")
 	ErrWriteJSONFile    = errors.New("failed to write JSON to file")
 	ErrDeleteJSONFile   = errors.New("failed to delete JSON file")
-	ErrNotFound         = errors.New("failed to find JSON file")
 )
 
 type IOHandler interface {
@@ -38,9 +37,6 @@ func (h *IOHandlerProvider) Read(clusterName string) ([]byte, error) {
 	fileName := path.Join(h.schemasDir, clusterName)
 	JSON, err := os.ReadFile(fileName)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, ErrNotFound
-		}
 		return nil, errors.Join(ErrReadJSONFile, err)
 	}
 	return JSON, nil


### PR DESCRIPTION
We got regression in this commit:
https://github.com/openmfp/kubernetes-graphql-gateway/commit/f5fb2ff28c7d9085c14169b86e3689e070f5c862#diff-f68d77da2f2e5f8b9de8494d1af405ee890ff3e1f0d0e4a4a58950da4552f4ce

kcp part was not tested and it was mentioned. 
Takeout - we should test both kcp and standart modes even if change is not seems to be related.

# Chages
- Removed ErrReadJSON because kcp check is based on fs.ErrNotExist.
- Removed JSON Read/Write errors from controller package - we don't need them there since we got it from iohandler package.

# Testing
- Tested at local-setup
<img width="1024" alt="Screenshot 2025-06-03 at 13 35 15" src="https://github.com/user-attachments/assets/1e28fe99-a124-4c83-a3f3-d338cc2d4d93" />


# TBD
- Checking right know if feature for listener that was introduced in mentioned commit is still there, will update this comment after.

On-behalf-of: @SAP a.shcherbatiuk@sap.com