### PR TITLE
Fix: config panic

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -67,8 +67,8 @@ func initConfig() {
 	v.SetDefault("gateway-handler-graphiql", true)
 	// Gateway CORS
 	v.SetDefault("gateway-cors-enabled", false)
-	v.SetDefault("gateway-cors-allowed-origins", []string{"*"})
-	v.SetDefault("gateway-cors-allowed-headers", []string{"*"})
+	v.SetDefault("gateway-cors-allowed-origins", "*")
+	v.SetDefault("gateway-cors-allowed-headers", "*")
 }
 
 func Execute() {

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -22,9 +22,9 @@ type Config struct {
 		} `mapstructure:",squash"`
 
 		Cors struct {
-			Enabled        bool     `mapstructure:"gateway-cors-enabled"`
-			AllowedOrigins []string `mapstructure:"gateway-cors-allowed-origins"`
-			AllowedHeaders []string `mapstructure:"gateway-cors-allowed-headers"`
+			Enabled        bool   `mapstructure:"gateway-cors-enabled"`
+			AllowedOrigins string `mapstructure:"gateway-cors-allowed-origins"`
+			AllowedHeaders string `mapstructure:"gateway-cors-allowed-headers"`
 		} `mapstructure:",squash"`
 	} `mapstructure:",squash"`
 }

--- a/gateway/manager/export_test.go
+++ b/gateway/manager/export_test.go
@@ -10,8 +10,8 @@ import (
 func NewManagerForTest() *Service {
 	cfg := appConfig.Config{}
 	cfg.Gateway.Cors.Enabled = true
-	cfg.Gateway.Cors.AllowedOrigins = []string{"*"}
-	cfg.Gateway.Cors.AllowedHeaders = []string{"Authorization"}
+	cfg.Gateway.Cors.AllowedOrigins = "*"
+	cfg.Gateway.Cors.AllowedHeaders = "Authorization"
 
 	s := &Service{
 		AppCfg:   cfg,

--- a/gateway/manager/handler.go
+++ b/gateway/manager/handler.go
@@ -79,10 +79,8 @@ func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func (s *Service) handleCORS(w http.ResponseWriter, r *http.Request) bool {
 	if s.AppCfg.Gateway.Cors.Enabled {
-		allowedOrigins := strings.Join(s.AppCfg.Gateway.Cors.AllowedOrigins, ",")
-		allowedHeaders := strings.Join(s.AppCfg.Gateway.Cors.AllowedHeaders, ",")
-		w.Header().Set("Access-Control-Allow-Origin", allowedOrigins)
-		w.Header().Set("Access-Control-Allow-Headers", allowedHeaders)
+		w.Header().Set("Access-Control-Allow-Origin", s.AppCfg.Gateway.Cors.AllowedOrigins)
+		w.Header().Set("Access-Control-Allow-Headers", s.AppCfg.Gateway.Cors.AllowedHeaders)
 		// setting cors allowed methods is not needed for this service,
 		// as all graphql methods are part of the cors safelisted methods
 		// https://fetch.spec.whatwg.org/#cors-safelisted-method


### PR DESCRIPTION
# Context
Config panics during service start because we don't support slices and in newer golang-commons version default case was added with the panic in case of wrong data type. (before it we didn't have it, so the compiler did nothing in case of slices).

# Changes
Changed slices in app cfg to strings

# Testing
Tested in local-setup by creating an account.
<img width="1299" alt="Screenshot 2025-06-30 at 14 42 56" src="https://github.com/user-attachments/assets/c417aaf3-a346-4004-80b4-d349472201d9" />
