### PR TITLE
 fix: auth issues

### DIFF
--- a/gateway/manager/roundtripper/roundtripper.go
+++ b/gateway/manager/roundtripper/roundtripper.go
@@ -1,68 +1,141 @@
 package roundtripper
 
 import (
-	"net/http"
-
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/openmfp/golang-commons/logger"
 	"k8s.io/client-go/transport"
+	"net/http"
+	"strings"
+
+	"github.com/openmfp/kubernetes-graphql-gateway/common/config"
 )
 
 type TokenKey struct{}
 
-// RoundTripper handles authentication and impersonation for HTTP requests
-type RoundTripper struct {
-	userClaim   string
-	log         *logger.Logger
-	base        http.RoundTripper
-	impersonate bool
+type roundTripper struct {
+	log                     *logger.Logger
+	adminRT, unauthorizedRT http.RoundTripper
+	appCfg                  config.Config
 }
 
-// New creates a new round tripper with the specified configuration
-func New(log *logger.Logger, base http.RoundTripper, userNameClaim string, impersonate bool) http.RoundTripper {
-	return &RoundTripper{
-		log:         log,
-		base:        base,
-		userClaim:   userNameClaim,
-		impersonate: impersonate,
+type unauthorizedRoundTripper struct{}
+
+func New(log *logger.Logger, appCfg config.Config, adminRoundTripper, unauthorizedRT http.RoundTripper) http.RoundTripper {
+	return &roundTripper{
+		log:            log,
+		adminRT:        adminRoundTripper,
+		unauthorizedRT: unauthorizedRT,
+		appCfg:         appCfg,
 	}
 }
 
-func (rt *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+// NewUnauthorizedRoundTripper returns a RoundTripper that always returns 401 Unauthorized
+func NewUnauthorizedRoundTripper() http.RoundTripper {
+	return &unauthorizedRoundTripper{}
+}
+
+func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.log.Debug().
+		Str("path", req.URL.Path).
+		Str("method", req.Method).
+		Bool("localDev", rt.appCfg.LocalDevelopment).
+		Bool("shouldImpersonate", rt.appCfg.Gateway.ShouldImpersonate).
+		Str("usernameClaim", rt.appCfg.Gateway.UsernameClaim).
+		Msg("RoundTripper processing request")
+
+	if rt.appCfg.LocalDevelopment {
+		rt.log.Debug().Str("path", req.URL.Path).Msg("Local development mode, using admin credentials")
+		return rt.adminRT.RoundTrip(req)
+	}
+
+	// client-go sends discovery requests to the Kubernetes API server before any CRUD request.
+	// And it doesn't attach any authentication token to these requests, even if we put token into the context at ServeHTTP method.
+	// That is why we don't protect discovery requests with authentication.
+	if isDiscoveryRequest(req) {
+		rt.log.Debug().Str("path", req.URL.Path).Msg("Discovery request detected, allowing with admin credentials")
+		return rt.adminRT.RoundTrip(req)
+	}
+
 	token, ok := req.Context().Value(TokenKey{}).(string)
-	if !ok {
-		rt.log.Debug().Msg("No token found in context")
-		return rt.base.RoundTrip(req)
+	if !ok || token == "" {
+		rt.log.Error().Str("path", req.URL.Path).Msg("No token found for resource request, denying")
+		return rt.unauthorizedRT.RoundTrip(req)
 	}
 
-	if !rt.impersonate {
-		req.Header.Del("Authorization")
-		t := transport.NewBearerAuthRoundTripper(token, rt.base)
-		return t.RoundTrip(req)
+	// No we are going to use token based auth only, so we are reassigning the headers
+	req.Header.Del("Authorization")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	if !rt.appCfg.Gateway.ShouldImpersonate {
+		rt.log.Debug().Str("path", req.URL.Path).Msg("Using bearer token authentication")
+
+		return rt.adminRT.RoundTrip(req)
 	}
 
+	// Impersonation mode: extract user from token and impersonate
+	rt.log.Debug().Str("path", req.URL.Path).Msg("Using impersonation mode")
 	claims := jwt.MapClaims{}
 	_, _, err := jwt.NewParser().ParseUnverified(token, claims)
 	if err != nil {
-		rt.log.Error().Err(err).Msg("Failed to parse token")
-		return rt.base.RoundTrip(req)
+		rt.log.Error().Err(err).Str("path", req.URL.Path).Msg("Failed to parse token for impersonation, denying request")
+		return rt.unauthorizedRT.RoundTrip(req)
 	}
 
-	userNameRaw, ok := claims[rt.userClaim]
+	userNameRaw, ok := claims[rt.appCfg.Gateway.UsernameClaim]
 	if !ok {
-		rt.log.Debug().Msg("No user claim found in token")
-		return rt.base.RoundTrip(req)
+		rt.log.Error().Str("path", req.URL.Path).Str("usernameClaim", rt.appCfg.Gateway.UsernameClaim).Msg("No user claim found in token for impersonation, denying request")
+		return rt.unauthorizedRT.RoundTrip(req)
 	}
 
 	userName, ok := userNameRaw.(string)
-	if !ok {
-		rt.log.Debug().Msg("User claim is not a string")
-		return rt.base.RoundTrip(req)
+	if !ok || userName == "" {
+		rt.log.Error().Str("path", req.URL.Path).Str("usernameClaim", rt.appCfg.Gateway.UsernameClaim).Msg("User claim is not a valid string for impersonation, denying request")
+		return rt.unauthorizedRT.RoundTrip(req)
 	}
 
-	t := transport.NewImpersonatingRoundTripper(transport.ImpersonationConfig{
-		UserName: userName,
-	}, rt.base)
+	rt.log.Debug().Str("path", req.URL.Path).Str("impersonateUser", userName).Msg("Impersonating user")
 
-	return t.RoundTrip(req)
+	impersonatingRT := transport.NewImpersonatingRoundTripper(transport.ImpersonationConfig{
+		UserName: userName,
+	}, rt.adminRT)
+
+	return impersonatingRT.RoundTrip(req)
+}
+
+func (u *unauthorizedRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusUnauthorized,
+		Request:    req,
+		Body:       http.NoBody,
+	}, nil
+}
+
+func isDiscoveryRequest(req *http.Request) bool {
+	if req.Method != http.MethodGet {
+		return false
+	}
+
+	// in case of kcp, the req.URL.Path contains /clusters/<workspace> prefix, which we need to trim for further check.
+	path := strings.TrimPrefix(req.URL.Path, req.URL.RawPath)
+	path = strings.Trim(path, "/") // remove leading and trailing slashes
+	parts := strings.Split(path, "/")
+
+	// Handle KCP workspace prefixes: /clusters/<workspace>/api or /clusters/<workspace>/apis
+	if len(parts) >= 3 && parts[0] == "clusters" {
+		// Remove /clusters/<workspace> prefix
+		parts = parts[2:]
+	}
+
+	switch {
+	case len(parts) == 1 && (parts[0] == "api" || parts[0] == "apis"):
+		return true // /api or /apis (root groups)
+	case len(parts) == 2 && parts[0] == "apis":
+		return true // /apis/<group>
+	case len(parts) == 2 && parts[0] == "api":
+		return true // /api/v1 (core group version)
+	case len(parts) == 3 && parts[0] == "apis":
+		return true // /apis/<group>/<version>
+	default:
+		return false
+	}
 }

--- a/gateway/manager/roundtripper/roundtripper_test.go
+++ b/gateway/manager/roundtripper/roundtripper_test.go
@@ -11,73 +11,78 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"k8s.io/client-go/transport"
 
+	appConfig "github.com/openmfp/kubernetes-graphql-gateway/common/config"
 	"github.com/openmfp/kubernetes-graphql-gateway/gateway/manager/mocks"
 	"github.com/openmfp/kubernetes-graphql-gateway/gateway/manager/roundtripper"
 )
 
 func TestRoundTripper_RoundTrip(t *testing.T) {
 	tests := []struct {
-		name         string
-		token        string
-		impersonate  bool
-		expectedUser string
+		name               string
+		token              string
+		localDevelopment   bool
+		shouldImpersonate  bool
+		expectedStatusCode int
+		setupMocks         func(*mocks.MockRoundTripper, *mocks.MockRoundTripper)
 	}{
 		{
-			name:         "success",
-			token:        createTestToken(t, jwt.MapClaims{"sub": "test-user"}),
-			impersonate:  true,
-			expectedUser: "test-user",
+			name:               "local_development_uses_admin",
+			localDevelopment:   true,
+			expectedStatusCode: http.StatusOK,
+			setupMocks: func(admin, unauthorized *mocks.MockRoundTripper) {
+				admin.EXPECT().RoundTrip(mock.Anything).Return(&http.Response{StatusCode: http.StatusOK}, nil)
+			},
 		},
 		{
-			name:        "no_token_in_context",
-			impersonate: false,
+			name:               "no_token_returns_unauthorized",
+			localDevelopment:   false,
+			expectedStatusCode: http.StatusUnauthorized,
+			setupMocks: func(admin, unauthorized *mocks.MockRoundTripper) {
+				unauthorized.EXPECT().RoundTrip(mock.Anything).Return(&http.Response{StatusCode: http.StatusUnauthorized}, nil)
+			},
 		},
 		{
-			name:        "token_present_impersonate_false",
-			token:       "valid-token",
-			impersonate: false,
+			name:               "valid_token_without_impersonation",
+			token:              "valid-token",
+			localDevelopment:   false,
+			shouldImpersonate:  false,
+			expectedStatusCode: http.StatusOK,
+			setupMocks: func(admin, unauthorized *mocks.MockRoundTripper) {
+				admin.EXPECT().RoundTrip(mock.Anything).Return(&http.Response{StatusCode: http.StatusOK}, nil)
+			},
 		},
 		{
-			name:        "failed_to_parse_token",
-			token:       "invalid-token",
-			impersonate: true,
-		},
-		{
-			name:        "user_claim_not_found",
-			token:       createTestToken(t, jwt.MapClaims{}),
-			impersonate: true,
-		},
-		{
-			name:        "user_claim_is_not_a_string",
-			token:       createTestToken(t, jwt.MapClaims{"sub": 123}),
-			impersonate: true,
+			name:               "valid_token_with_impersonation",
+			token:              createTestToken(t, jwt.MapClaims{"sub": "test-user"}),
+			localDevelopment:   false,
+			shouldImpersonate:  true,
+			expectedStatusCode: http.StatusOK,
+			setupMocks: func(admin, unauthorized *mocks.MockRoundTripper) {
+				admin.EXPECT().RoundTrip(mock.Anything).Return(&http.Response{StatusCode: http.StatusOK}, nil)
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mockRoundTripper := &mocks.MockRoundTripper{}
+			mockAdmin := &mocks.MockRoundTripper{}
+			mockUnauthorized := &mocks.MockRoundTripper{}
 
-			mockRoundTripper.EXPECT().
-				RoundTrip(mock.Anything).
-				Return(&http.Response{StatusCode: http.StatusOK}, nil)
-
-			if tt.expectedUser != "" {
-				mockRoundTripper.EXPECT().
-					RoundTrip(mock.MatchedBy(func(req *http.Request) bool {
-						return req.Header.Get(transport.ImpersonateUserHeader) == tt.expectedUser
-					})).
-					Return(&http.Response{StatusCode: http.StatusOK}, nil)
-			}
+			tt.setupMocks(mockAdmin, mockUnauthorized)
 
 			log, err := logger.New(logger.DefaultConfig())
 			require.NoError(t, err)
 
-			rt := roundtripper.New(log, mockRoundTripper, "sub", tt.impersonate)
+			appCfg := appConfig.Config{
+				LocalDevelopment: tt.localDevelopment,
+			}
+			appCfg.Gateway.ShouldImpersonate = tt.shouldImpersonate
+			appCfg.Gateway.UsernameClaim = "sub"
 
-			req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
+			rt := roundtripper.New(log, appCfg, mockAdmin, mockUnauthorized)
+
+			req := httptest.NewRequest(http.MethodGet, "http://example.com/api/v1/pods", nil)
 			if tt.token != "" {
 				ctx := context.WithValue(req.Context(), roundtripper.TokenKey{}, tt.token)
 				req = req.WithContext(ctx)
@@ -86,9 +91,279 @@ func TestRoundTripper_RoundTrip(t *testing.T) {
 			resp, err := rt.RoundTrip(req)
 			require.NoError(t, err)
 			require.NotNil(t, resp)
-			assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-			mockRoundTripper.AssertExpectations(t)
+			assert.Equal(t, tt.expectedStatusCode, resp.StatusCode)
+
+			mockAdmin.AssertExpectations(t)
+			mockUnauthorized.AssertExpectations(t)
+		})
+	}
+}
+
+func TestRoundTripper_DiscoveryRequests(t *testing.T) {
+	tests := []struct {
+		name        string
+		method      string
+		path        string
+		isDiscovery bool
+	}{
+		{
+			name:        "api_root_discovery",
+			method:      "GET",
+			path:        "/api",
+			isDiscovery: true,
+		},
+		{
+			name:        "apis_root_discovery",
+			method:      "GET",
+			path:        "/apis",
+			isDiscovery: true,
+		},
+		{
+			name:        "resource_request",
+			method:      "GET",
+			path:        "/api/v1/pods",
+			isDiscovery: false,
+		},
+		{
+			name:        "post_request",
+			method:      "POST",
+			path:        "/api/v1/pods",
+			isDiscovery: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockAdmin := &mocks.MockRoundTripper{}
+			mockUnauthorized := &mocks.MockRoundTripper{}
+
+			if tt.isDiscovery {
+				mockAdmin.EXPECT().RoundTrip(mock.Anything).Return(&http.Response{StatusCode: http.StatusOK}, nil)
+			} else {
+				mockUnauthorized.EXPECT().RoundTrip(mock.Anything).Return(&http.Response{StatusCode: http.StatusUnauthorized}, nil)
+			}
+
+			log, err := logger.New(logger.DefaultConfig())
+			require.NoError(t, err)
+
+			appCfg := appConfig.Config{
+				LocalDevelopment: false,
+			}
+			appCfg.Gateway.ShouldImpersonate = false
+			appCfg.Gateway.UsernameClaim = "sub"
+
+			rt := roundtripper.New(log, appCfg, mockAdmin, mockUnauthorized)
+
+			req := httptest.NewRequest(tt.method, "http://example.com"+tt.path, nil)
+
+			resp, err := rt.RoundTrip(req)
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+
+			if tt.isDiscovery {
+				assert.Equal(t, http.StatusOK, resp.StatusCode)
+			} else {
+				assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+			}
+
+			mockAdmin.AssertExpectations(t)
+			mockUnauthorized.AssertExpectations(t)
+		})
+	}
+}
+
+func TestRoundTripper_ComprehensiveFunctionality(t *testing.T) {
+	tests := []struct {
+		name                  string
+		token                 string
+		localDevelopment      bool
+		shouldImpersonate     bool
+		usernameClaim         string
+		expectedStatusCode    int
+		expectedImpersonation string
+		setupMocks            func(*mocks.MockRoundTripper, *mocks.MockRoundTripper)
+	}{
+		{
+			name:                  "impersonation_with_custom_claim",
+			token:                 createTestTokenWithClaim(t, "email", "user@example.com"),
+			localDevelopment:      false,
+			shouldImpersonate:     true,
+			usernameClaim:         "email",
+			expectedStatusCode:    http.StatusOK,
+			expectedImpersonation: "user@example.com",
+			setupMocks: func(admin, unauthorized *mocks.MockRoundTripper) {
+				admin.EXPECT().RoundTrip(mock.Anything).Return(&http.Response{StatusCode: http.StatusOK}, nil)
+			},
+		},
+		{
+			name:                  "impersonation_with_sub_claim",
+			token:                 createTestTokenWithClaim(t, "sub", "test-user-123"),
+			localDevelopment:      false,
+			shouldImpersonate:     true,
+			usernameClaim:         "sub",
+			expectedStatusCode:    http.StatusOK,
+			expectedImpersonation: "test-user-123",
+			setupMocks: func(admin, unauthorized *mocks.MockRoundTripper) {
+				admin.EXPECT().RoundTrip(mock.Anything).Return(&http.Response{StatusCode: http.StatusOK}, nil)
+			},
+		},
+		{
+			name:               "missing_user_claim_returns_unauthorized",
+			token:              createTestTokenWithClaim(t, "other_claim", "value"),
+			localDevelopment:   false,
+			shouldImpersonate:  true,
+			usernameClaim:      "sub",
+			expectedStatusCode: http.StatusUnauthorized,
+			setupMocks: func(admin, unauthorized *mocks.MockRoundTripper) {
+				unauthorized.EXPECT().RoundTrip(mock.Anything).Return(&http.Response{StatusCode: http.StatusUnauthorized}, nil)
+			},
+		},
+		{
+			name:               "invalid_token_returns_unauthorized",
+			token:              "invalid.jwt.token",
+			localDevelopment:   false,
+			shouldImpersonate:  true,
+			usernameClaim:      "sub",
+			expectedStatusCode: http.StatusUnauthorized,
+			setupMocks: func(admin, unauthorized *mocks.MockRoundTripper) {
+				unauthorized.EXPECT().RoundTrip(mock.Anything).Return(&http.Response{StatusCode: http.StatusUnauthorized}, nil)
+			},
+		},
+		{
+			name:               "empty_user_claim_returns_unauthorized",
+			token:              createTestTokenWithClaim(t, "sub", ""),
+			localDevelopment:   false,
+			shouldImpersonate:  true,
+			usernameClaim:      "sub",
+			expectedStatusCode: http.StatusUnauthorized,
+			setupMocks: func(admin, unauthorized *mocks.MockRoundTripper) {
+				unauthorized.EXPECT().RoundTrip(mock.Anything).Return(&http.Response{StatusCode: http.StatusUnauthorized}, nil)
+			},
+		},
+		{
+			name:               "non_string_user_claim_returns_unauthorized",
+			token:              createTestTokenWithClaim(t, "sub", 12345),
+			localDevelopment:   false,
+			shouldImpersonate:  true,
+			usernameClaim:      "sub",
+			expectedStatusCode: http.StatusUnauthorized,
+			setupMocks: func(admin, unauthorized *mocks.MockRoundTripper) {
+				unauthorized.EXPECT().RoundTrip(mock.Anything).Return(&http.Response{StatusCode: http.StatusUnauthorized}, nil)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockAdmin := &mocks.MockRoundTripper{}
+			mockUnauthorized := &mocks.MockRoundTripper{}
+
+			tt.setupMocks(mockAdmin, mockUnauthorized)
+
+			log, err := logger.New(logger.DefaultConfig())
+			require.NoError(t, err)
+
+			appCfg := appConfig.Config{
+				LocalDevelopment: tt.localDevelopment,
+			}
+			appCfg.Gateway.ShouldImpersonate = tt.shouldImpersonate
+			appCfg.Gateway.UsernameClaim = tt.usernameClaim
+
+			rt := roundtripper.New(log, appCfg, mockAdmin, mockUnauthorized)
+
+			req := httptest.NewRequest(http.MethodGet, "http://example.com/api/v1/pods", nil)
+			if tt.token != "" {
+				ctx := context.WithValue(req.Context(), roundtripper.TokenKey{}, tt.token)
+				req = req.WithContext(ctx)
+			}
+
+			resp, err := rt.RoundTrip(req)
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+
+			assert.Equal(t, tt.expectedStatusCode, resp.StatusCode)
+
+			mockAdmin.AssertExpectations(t)
+			mockUnauthorized.AssertExpectations(t)
+		})
+	}
+}
+
+func TestRoundTripper_KCPDiscoveryRequests(t *testing.T) {
+	tests := []struct {
+		name        string
+		path        string
+		isDiscovery bool
+	}{
+		{
+			name:        "kcp_clusters_api_discovery",
+			path:        "/clusters/workspace1/api",
+			isDiscovery: true,
+		},
+		{
+			name:        "kcp_clusters_apis_discovery",
+			path:        "/clusters/workspace1/apis",
+			isDiscovery: true,
+		},
+		{
+			name:        "kcp_clusters_apis_group_discovery",
+			path:        "/clusters/workspace1/apis/apps",
+			isDiscovery: true,
+		},
+		{
+			name:        "kcp_clusters_apis_group_version_discovery",
+			path:        "/clusters/workspace1/apis/apps/v1",
+			isDiscovery: true,
+		},
+		{
+			name:        "kcp_clusters_api_version_discovery",
+			path:        "/clusters/workspace1/api/v1",
+			isDiscovery: true,
+		},
+		{
+			name:        "kcp_clusters_resource_request",
+			path:        "/clusters/workspace1/api/v1/pods",
+			isDiscovery: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockAdmin := &mocks.MockRoundTripper{}
+			mockUnauthorized := &mocks.MockRoundTripper{}
+
+			if tt.isDiscovery {
+				mockAdmin.EXPECT().RoundTrip(mock.Anything).Return(&http.Response{StatusCode: http.StatusOK}, nil)
+			} else {
+				mockUnauthorized.EXPECT().RoundTrip(mock.Anything).Return(&http.Response{StatusCode: http.StatusUnauthorized}, nil)
+			}
+
+			log, err := logger.New(logger.DefaultConfig())
+			require.NoError(t, err)
+
+			appCfg := appConfig.Config{
+				LocalDevelopment: false,
+			}
+			appCfg.Gateway.ShouldImpersonate = false
+			appCfg.Gateway.UsernameClaim = "sub"
+
+			rt := roundtripper.New(log, appCfg, mockAdmin, mockUnauthorized)
+
+			req := httptest.NewRequest(http.MethodGet, "http://example.com"+tt.path, nil)
+
+			resp, err := rt.RoundTrip(req)
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+
+			if tt.isDiscovery {
+				assert.Equal(t, http.StatusOK, resp.StatusCode)
+			} else {
+				assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+			}
+
+			mockAdmin.AssertExpectations(t)
+			mockUnauthorized.AssertExpectations(t)
 		})
 	}
 }
@@ -98,4 +373,136 @@ func createTestToken(t *testing.T, claims jwt.MapClaims) string {
 	signedToken, err := token.SignedString([]byte("test-secret"))
 	require.NoError(t, err)
 	return signedToken
+}
+
+func createTestTokenWithClaim(t *testing.T, claimKey string, claimValue interface{}) string {
+	claims := jwt.MapClaims{claimKey: claimValue}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signedToken, err := token.SignedString([]byte("test-secret"))
+	require.NoError(t, err)
+	return signedToken
+}
+
+func TestRoundTripper_InvalidTokenSecurityFix(t *testing.T) {
+	// This test verifies that the security fix works: invalid tokens should be rejected
+	// by the Kubernetes cluster itself, not by falling back to admin credentials
+
+	mockAdmin := &mocks.MockRoundTripper{}
+	mockUnauthorized := &mocks.MockRoundTripper{}
+
+	// The unauthorizedRT should be called since we have no token
+	mockUnauthorized.EXPECT().RoundTrip(mock.Anything).Return(&http.Response{StatusCode: http.StatusUnauthorized}, nil)
+
+	log, err := logger.New(logger.DefaultConfig())
+	require.NoError(t, err)
+
+	appCfg := appConfig.Config{}
+	appCfg.Gateway.ShouldImpersonate = false
+	appCfg.Gateway.UsernameClaim = "sub"
+
+	rt := roundtripper.New(log, appCfg, mockAdmin, mockUnauthorized)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/pods", nil)
+	// Don't set a token to simulate the invalid token case
+
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+func TestRoundTripper_ExistingAuthHeadersAreCleanedBeforeTokenAuth(t *testing.T) {
+	// This test verifies that existing Authorization headers are properly cleaned
+	// before setting the bearer token, preventing admin credentials from leaking through
+
+	mockAdmin := &mocks.MockRoundTripper{}
+	mockUnauthorized := &mocks.MockRoundTripper{}
+
+	// Capture the request that gets sent to adminRT
+	var capturedRequest *http.Request
+	mockAdmin.EXPECT().RoundTrip(mock.Anything).Return(&http.Response{StatusCode: http.StatusOK}, nil).Run(func(req *http.Request) {
+		capturedRequest = req
+	})
+
+	log, err := logger.New(logger.DefaultConfig())
+	require.NoError(t, err)
+
+	appCfg := appConfig.Config{}
+	appCfg.Gateway.ShouldImpersonate = false
+	appCfg.Gateway.UsernameClaim = "sub"
+
+	rt := roundtripper.New(log, appCfg, mockAdmin, mockUnauthorized)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/pods", nil)
+
+	// Set an existing Authorization header that should be cleaned
+	req.Header.Set("Authorization", "Bearer admin-token-that-should-be-removed")
+
+	// Add the token to context
+	req = req.WithContext(context.WithValue(req.Context(), roundtripper.TokenKey{}, "user-token"))
+
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Verify that the captured request has the correct Authorization header
+	require.NotNil(t, capturedRequest)
+	authHeader := capturedRequest.Header.Get("Authorization")
+	assert.Equal(t, "Bearer user-token", authHeader)
+
+	// Verify that the original admin token was removed
+	assert.NotContains(t, authHeader, "admin-token-that-should-be-removed")
+}
+
+func TestRoundTripper_ExistingAuthHeadersAreCleanedBeforeImpersonation(t *testing.T) {
+	// This test verifies that existing Authorization headers are properly cleaned
+	// before setting the bearer token in impersonation mode
+
+	mockAdmin := &mocks.MockRoundTripper{}
+	mockUnauthorized := &mocks.MockRoundTripper{}
+
+	// Capture the request that gets sent to the impersonation round tripper (which uses adminRT)
+	var capturedRequest *http.Request
+	mockAdmin.EXPECT().RoundTrip(mock.Anything).Return(&http.Response{StatusCode: http.StatusOK}, nil).Run(func(req *http.Request) {
+		capturedRequest = req
+	})
+
+	log, err := logger.New(logger.DefaultConfig())
+	require.NoError(t, err)
+
+	appCfg := appConfig.Config{}
+	appCfg.Gateway.ShouldImpersonate = true
+	appCfg.Gateway.UsernameClaim = "sub"
+
+	rt := roundtripper.New(log, appCfg, mockAdmin, mockUnauthorized)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/pods", nil)
+
+	// Set an existing Authorization header that should be cleaned
+	req.Header.Set("Authorization", "Bearer admin-token-that-should-be-removed")
+
+	// Create a valid JWT token with user claim
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"sub": "test-user",
+	})
+	tokenString, err := token.SignedString([]byte("secret"))
+	require.NoError(t, err)
+
+	// Add the token to context
+	req = req.WithContext(context.WithValue(req.Context(), roundtripper.TokenKey{}, tokenString))
+
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Verify that the captured request has the correct Authorization header
+	require.NotNil(t, capturedRequest)
+	authHeader := capturedRequest.Header.Get("Authorization")
+	assert.Equal(t, "Bearer "+tokenString, authHeader)
+
+	// Verify that the original admin token was removed
+	assert.NotContains(t, authHeader, "admin-token-that-should-be-removed")
+
+	// Verify that the impersonation header is set
+	impersonateHeader := capturedRequest.Header.Get("Impersonate-User")
+	assert.Equal(t, "test-user", impersonateHeader)
 }

--- a/gateway/manager/targetcluster/cluster.go
+++ b/gateway/manager/targetcluster/cluster.go
@@ -100,8 +100,8 @@ func (tc *TargetCluster) connect(appCfg appConfig.Config, metadata *ClusterMetad
 	var config *rest.Config
 	var err error
 
-	// In multicluster mode, we MUST have metadata to connect (unless in local development)
-	if !appCfg.EnableKcp && appCfg.MultiCluster && !appCfg.LocalDevelopment {
+	// In multicluster mode, we MUST have metadata to connect
+	if !appCfg.EnableKcp && appCfg.MultiCluster {
 		if metadata == nil {
 			return fmt.Errorf("multicluster mode requires cluster metadata in schema file")
 		}
@@ -116,7 +116,7 @@ func (tc *TargetCluster) connect(appCfg appConfig.Config, metadata *ClusterMetad
 			return fmt.Errorf("failed to build config from metadata: %w", err)
 		}
 	} else {
-		// Single cluster, KCP mode, or local development - use standard config
+		// Single cluster, KCP mode
 		tc.log.Info().
 			Str("cluster", tc.name).
 			Bool("enableKcp", appCfg.EnableKcp).

--- a/gateway/manager/targetcluster/cluster.go
+++ b/gateway/manager/targetcluster/cluster.go
@@ -53,6 +53,7 @@ type CAMetadata struct {
 type TargetCluster struct {
 	name          string
 	client        client.WithWatch
+	restCfg       *rest.Config
 	handler       *GraphQLHandler
 	graphqlServer *GraphQLServer
 	log           *logger.Logger
@@ -152,6 +153,8 @@ func (tc *TargetCluster) connect(appCfg appConfig.Config, metadata *ClusterMetad
 	if err != nil {
 		return fmt.Errorf("failed to create cluster client: %w", err)
 	}
+
+	tc.restCfg = config
 
 	return nil
 }
@@ -261,6 +264,11 @@ func (tc *TargetCluster) createHandler(definitions map[string]interface{}, appCf
 // GetName returns the cluster name
 func (tc *TargetCluster) GetName() string {
 	return tc.name
+}
+
+// GetConfig returns the cluster's rest.Config
+func (tc *TargetCluster) GetConfig() *rest.Config {
+	return tc.restCfg
 }
 
 // GetEndpoint returns the HTTP endpoint for this cluster's GraphQL API

--- a/gateway/resolver/resolver.go
+++ b/gateway/resolver/resolver.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/graphql-go/graphql"
+	pkgErrors "github.com/pkg/errors"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -108,7 +109,7 @@ func (r *Service) ListItems(gvk schema.GroupVersionKind, scope v1.ResourceScope)
 
 		if err = r.runtimeClient.List(ctx, list, opts...); err != nil {
 			log.Error().Err(err).Msg("Unable to list objects")
-			return nil, err
+			return nil, pkgErrors.Wrap(err, "unable to list objects")
 		}
 
 		sortBy, err := getStringArg(p.Args, SortByArg, false)


### PR DESCRIPTION
Resolves #200 


1. Now, if INTROSPECTION_AUTHENTICATION=true, schema fetching is failing in case of invalid token.
2. Also, in case of invalid token we will not get resources for ClusterAccess and KCP flows.

## Changes
Mostly this two lines does the job:
	req.Header.Del("Authorization")
	req.Header.Set("Authorization", "Bearer "+token)
	
Also, I returned isDiscoveryRequest func to pass the admin rountripper during that request.

## Testing
1. Tested locally with clusterAccess 
2. Tested in local-setup by loading image built locally with the same tag.
<img width="1312" alt="Screenshot 2025-07-08 at 18 31 07" src="https://github.com/user-attachments/assets/4c75df2c-ed01-400c-ab1d-05999bb4465e" />

