### PR TITLE
fix(auth): remove debug print statement for bearer token 

### DIFF
--- a/common/auth/config.go
+++ b/common/auth/config.go
@@ -296,8 +296,6 @@ func ConfigureAuthentication(config *rest.Config, auth *gatewayv1alpha1.AuthConf
 		}
 
 		config.BearerToken = tokenRequest.Status.Token
-
-		fmt.Println("Token:", config.BearerToken)
 		return nil
 	}
 


### PR DESCRIPTION
Removed a debug statement from the previous implemented serviceaccount auth implementation